### PR TITLE
Adding Euskal Encounter series and all the parties to date.

### DIFF
--- a/data/parties/euskal-encounter/euskal-encounter-01.toml
+++ b/data/parties/euskal-encounter/euskal-encounter-01.toml
@@ -1,0 +1,10 @@
+slug = "euskal-amiga-party"
+title = "Euskal Amiga Party"
+series_slug = "euskal-encounter"
+start_on = 1994-08-06
+end_on = 1994-08-07
+seats = 25
+
+[location]
+country_code = "es"
+city = "Urretxu"   

--- a/data/parties/euskal-encounter/euskal-encounter-02.toml
+++ b/data/parties/euskal-encounter/euskal-encounter-02.toml
@@ -1,0 +1,10 @@
+slug = "euskal-amiga-party-2"
+title = "Euskal Amiga Party 2"
+series_slug = "euskal-encounter"
+start_on = 1994-12-27
+end_on = 1994-12-29
+seats = 80
+
+[location]
+country_code = "es"
+city = "Legazpi"

--- a/data/parties/euskal-encounter/euskal-encounter-03.toml
+++ b/data/parties/euskal-encounter/euskal-encounter-03.toml
@@ -1,0 +1,10 @@
+slug = "euskal-party-3"
+title = "Euskal Party 3"
+series_slug = "euskal-encounter"
+start_on = 1995-10-12
+end_on = 1995-10-15
+seats = 200
+
+[location]
+country_code = "es"
+city = "Tolosa"

--- a/data/parties/euskal-encounter/euskal-encounter-04.toml
+++ b/data/parties/euskal-encounter/euskal-encounter-04.toml
@@ -1,0 +1,10 @@
+slug = "euskal-party-4"
+title = "Euskal Party 4"
+series_slug = "euskal-encounter"
+start_on = 1996-07-25
+end_on = 1996-07-28
+seats = 280
+
+[location]
+country_code = "es"
+city = "Donostia"

--- a/data/parties/euskal-encounter/euskal-encounter-05.toml
+++ b/data/parties/euskal-encounter/euskal-encounter-05.toml
@@ -1,0 +1,10 @@
+slug = "euskal-party-5"
+title = "Euskal Party 5"
+series_slug = "euskal-encounter"
+start_on = 1997-07-25
+end_on = 1997-07-27
+seats = 300
+
+[location]
+country_code = "es"
+city = "Donostia"

--- a/data/parties/euskal-encounter/euskal-encounter-06.toml
+++ b/data/parties/euskal-encounter/euskal-encounter-06.toml
@@ -1,0 +1,10 @@
+slug = "euskal-party-6"
+title = "Euskal Party 6"
+series_slug = "euskal-encounter"
+start_on = 1998-07-24
+end_on = 1998-07-26
+seats = 425
+
+[location]
+country_code = "es"
+city = "Donostia"

--- a/data/parties/euskal-encounter/euskal-encounter-07.toml
+++ b/data/parties/euskal-encounter/euskal-encounter-07.toml
@@ -1,0 +1,13 @@
+slug = "euskal-party-7"
+title = "Euskal Party 7"
+series_slug = "euskal-encounter"
+start_on = 1999-07-23
+end_on = 1999-07-25
+seats = 560
+
+[location]
+country_code = "es"
+city = "Donostia"
+
+[links.website]
+url = "https://euskalencounter.org/euskal7/"

--- a/data/parties/euskal-encounter/euskal-encounter-08.toml
+++ b/data/parties/euskal-encounter/euskal-encounter-08.toml
@@ -1,0 +1,13 @@
+slug = "euskal-8"
+title = "Euskal 8"
+series_slug = "euskal-encounter"
+start_on = 2000-07-22
+end_on = 2000-07-22
+seats = 900
+
+[location]
+country_code = "es"
+city = "Bilbo"
+
+[links.website]
+url = "https://euskalencounter.org/euskal8/"

--- a/data/parties/euskal-encounter/euskal-encounter-09.toml
+++ b/data/parties/euskal-encounter/euskal-encounter-09.toml
@@ -1,0 +1,13 @@
+slug = "euskal-9"
+title = "Euskal 9"
+series_slug = "euskal-encounter"
+start_on = 2001-07-26
+end_on = 2001-07-29
+seats = 1200
+
+[location]
+country_code = "es"
+city = "Gasteiz"
+
+[links.website]
+url = "https://euskalencounter.org/euskal9/"

--- a/data/parties/euskal-encounter/euskal-encounter-10.toml
+++ b/data/parties/euskal-encounter/euskal-encounter-10.toml
@@ -1,0 +1,13 @@
+slug = "euskal-10"
+title = "Euskal 10"
+series_slug = "euskal-encounter"
+start_on = 2002-07-25
+end_on = 2002-07-28
+seats = 1600
+
+[location]
+country_code = "es"
+city = "Donostia"
+
+[links.website]
+url = "https://euskalencounter.org/euskal10/"

--- a/data/parties/euskal-encounter/euskal-encounter-11.toml
+++ b/data/parties/euskal-encounter/euskal-encounter-11.toml
@@ -1,0 +1,14 @@
+slug = "euskal-11"
+title = "Euskal 11"
+series_slug = "euskal-encounter"
+organizer_entity = ["Asociación Euskalamiga", "Fundación Euskaltel"]
+start_on = 2003-07-24
+end_on = 2003-07-27
+seats = 900
+
+[location]
+country_code = "es"
+city = "Bilbo"
+
+[links.website]
+url = "https://euskalencounter.org/euskal11/"

--- a/data/parties/euskal-encounter/euskal-encounter-12.toml
+++ b/data/parties/euskal-encounter/euskal-encounter-12.toml
@@ -1,0 +1,15 @@
+slug = "euskal-encounter-12"
+title = "Euskal Encounter 12"
+series_slug = "euskal-encounter"
+organizer_entity = ["Asociación Euskalamiga", "Fundación Euskaltel"]
+start_on = 2004-07-22
+end_on = 2004-07-25
+seats = 2560
+
+[location]
+name = "Bilbao Exhibition Centre (BEC)"
+country_code = "es"
+city = "Barakaldo"
+
+[links.website]
+url = "https://euskalencounter.org/euskal12/"

--- a/data/parties/euskal-encounter/euskal-encounter-13.toml
+++ b/data/parties/euskal-encounter/euskal-encounter-13.toml
@@ -1,0 +1,15 @@
+slug = "euskal-encounter-13"
+title = "Euskal Encounter 13"
+series_slug = "euskal-encounter"
+organizer_entity = ["Asociación Euskalamiga", "Fundación Euskaltel"]
+start_on = 2005-07-22
+end_on = 2005-07-25
+seats = 3072
+
+[location]
+name = "Bilbao Exhibition Centre (BEC)"
+country_code = "es"
+city = "Barakaldo"
+
+[links.website]
+url = "https://euskalencounter.org/euskal13/"

--- a/data/parties/euskal-encounter/euskal-encounter-14.toml
+++ b/data/parties/euskal-encounter/euskal-encounter-14.toml
@@ -1,0 +1,15 @@
+slug = "euskal-encounter-14"
+title = "Euskal Encounter 14"
+series_slug = "euskal-encounter"
+organizer_entity = ["Asociación Euskalamiga", "Fundación Euskaltel"]
+start_on = 2006-07-22
+end_on = 2006-07-25
+seats = 3584
+
+[location]
+name = "Bilbao Exhibition Centre (BEC)"
+country_code = "es"
+city = "Barakaldo"
+
+[links.website]
+url = "https://euskalencounter.org/euskal14/"

--- a/data/parties/euskal-encounter/euskal-encounter-15.toml
+++ b/data/parties/euskal-encounter/euskal-encounter-15.toml
@@ -1,0 +1,15 @@
+slug = "euskal-encounter-15"
+title = "Euskal Encounter 15"
+series_slug = "euskal-encounter"
+organizer_entity = ["Asociación Euskalamiga", "Fundación Euskaltel"]
+start_on = 2007-07-20
+end_on = 2007-07-23
+seats = 4096
+
+[location]
+name = "Bilbao Exhibition Centre (BEC)"
+country_code = "es"
+city = "Barakaldo"
+
+[links.website]
+url = "https://euskalencounter.org/euskal15/"

--- a/data/parties/euskal-encounter/euskal-encounter-16.toml
+++ b/data/parties/euskal-encounter/euskal-encounter-16.toml
@@ -1,0 +1,15 @@
+slug = "euskal-encounter-16"
+title = "Euskal Encounter 16"
+series_slug = "euskal-encounter"
+organizer_entity = ["Asociación Euskalamiga", "Fundación Euskaltel"]
+start_on = 2008-07-24
+end_on = 2008-07-27
+seats = 4096
+
+[location]
+name = "Bilbao Exhibition Centre (BEC)"
+country_code = "es"
+city = "Barakaldo"
+
+[links.website]
+url = "https://euskalencounter.org/euskal16/"

--- a/data/parties/euskal-encounter/euskal-encounter-17.toml
+++ b/data/parties/euskal-encounter/euskal-encounter-17.toml
@@ -1,0 +1,15 @@
+slug = "euskal-encounter-17"
+title = "Euskal Encounter 17"
+series_slug = "euskal-encounter"
+organizer_entity = ["Asociación Euskalamiga", "Fundación Euskaltel"]
+start_on = 2009-07-23
+end_on = 2009-07-26
+seats = 4096
+
+[location]
+name = "Bilbao Exhibition Centre (BEC)"
+country_code = "es"
+city = "Barakaldo"
+
+[links.website]
+url = "https://euskalencounter.org/euskal17/"

--- a/data/parties/euskal-encounter/euskal-encounter-18.toml
+++ b/data/parties/euskal-encounter/euskal-encounter-18.toml
@@ -1,0 +1,15 @@
+slug = "euskal-encounter-18"
+title = "Euskal Encounter 18"
+series_slug = "euskal-encounter"
+organizer_entity = ["Asociación Euskalamiga", "Fundación Euskaltel"]
+start_on = 2010-07-22
+end_on = 2010-07-25
+seats = 4096 
+
+[location]
+name = "Bilbao Exhibition Centre (BEC)"
+country_code = "es"
+city = "Barakaldo"
+
+[links.website]
+url = "https://euskalencounter.org/euskal18/"

--- a/data/parties/euskal-encounter/euskal-encounter-19.toml
+++ b/data/parties/euskal-encounter/euskal-encounter-19.toml
@@ -1,0 +1,15 @@
+slug = "euskal-encounter-19"
+title = "Euskal Encounter 19"
+series_slug = "euskal-encounter"
+organizer_entity = ["Asociación Euskalamiga", "Fundación Euskaltel"]
+start_on = 2011-07-22
+end_on = 2011-07-25
+seats = 2560
+
+[location]
+name = "Bilbao Exhibition Centre (BEC)"
+country_code = "es"
+city = "Barakaldo"
+
+[links.website]
+url = "https://euskalencounter.org/euskal19/"

--- a/data/parties/euskal-encounter/euskal-encounter-20.toml
+++ b/data/parties/euskal-encounter/euskal-encounter-20.toml
@@ -1,0 +1,15 @@
+slug = "euskal-encounter-20"
+title = "Euskal Encounter 20"
+series_slug = "euskal-encounter"
+organizer_entity = ["Asociación Euskalamiga", "Fundación Euskaltel"]
+start_on = 2012-07-26
+end_on = 2012-07-29
+seats = 4096
+
+[location]
+name = "Bilbao Exhibition Centre (BEC)"
+country_code = "es"
+city = "Barakaldo"
+
+[links.website]
+url = "https://euskalencounter.org/euskal20/"

--- a/data/parties/euskal-encounter/euskal-encounter-21.toml
+++ b/data/parties/euskal-encounter/euskal-encounter-21.toml
@@ -1,0 +1,15 @@
+slug = "euskal-encounter-21"
+title = "Euskal Encounter 21"
+series_slug = "euskal-encounter"
+organizer_entity = ["Asociación Euskalamiga", "Fundación Euskaltel"]
+start_on = 2013-07-25
+end_on = 2013-07-28
+seats = 4096
+
+[location]
+name = "Bilbao Exhibition Centre (BEC)"
+country_code = "es"
+city = "Barakaldo"
+
+[links.website]
+url = "https://euskalencounter.org/euskal21/"

--- a/data/parties/euskal-encounter/euskal-encounter-22.toml
+++ b/data/parties/euskal-encounter/euskal-encounter-22.toml
@@ -1,0 +1,15 @@
+slug = "euskal-encounter-22"
+title = "Euskal Encounter 22"
+series_slug = "euskal-encounter"
+organizer_entity = ["Asociación Euskalamiga", "Fundación Euskaltel"]
+start_on = 2014-07-24
+end_on = 2014-07-27
+seats = 4096
+
+[location]
+name = "Bilbao Exhibition Centre (BEC)"
+country_code = "es"
+city = "Barakaldo"
+
+[links.website]
+url = "https://euskalencounter.org/euskal22/"

--- a/data/parties/euskal-encounter/euskal-encounter-23.toml
+++ b/data/parties/euskal-encounter/euskal-encounter-23.toml
@@ -1,0 +1,15 @@
+slug = "euskal-encounter-23"
+title = "Euskal Encounter 23"
+series_slug = "euskal-encounter"
+organizer_entity = "Euskaltel Konekta"
+start_on = 2015-07-23
+end_on = 2015-07-26
+seats = 4096
+
+[location]
+name = "Bilbao Exhibition Centre (BEC)"
+country_code = "es"
+city = "Barakaldo"
+
+[links.website]
+url = "https://euskalencounter.org/euskal23/"

--- a/data/parties/euskal-encounter/euskal-encounter-24.toml
+++ b/data/parties/euskal-encounter/euskal-encounter-24.toml
@@ -1,0 +1,15 @@
+slug = "euskal-encounter-24"
+title = "Euskal Encounter 24"
+series_slug = "euskal-encounter"
+organizer_entity = "Euskaltel Konekta"
+start_on = 2016-07-22
+end_on = 2016-07-25
+seats = 4608
+
+[location]
+name = "Bilbao Exhibition Centre (BEC)"
+country_code = "es"
+city = "Barakaldo"
+
+[links.website]
+url = "https://euskalencounter.org/euskal24/"

--- a/data/parties/euskal-encounter/euskal-encounter-25.toml
+++ b/data/parties/euskal-encounter/euskal-encounter-25.toml
@@ -1,0 +1,15 @@
+slug = "euskal-encounter-25"
+title = "Euskal Encounter 25"
+series_slug = "euskal-encounter"
+organizer_entity = "Euskaltel Konekta"
+start_on = 2017-07-22
+end_on = 2017-07-25
+seats = 5024
+
+[location]
+name = "Bilbao Exhibition Centre (BEC)"
+country_code = "es"
+city = "Barakaldo"
+
+[links.website]
+url = "https://ee25.euskalencounter.org/"

--- a/data/parties/euskal-encounter/euskal-encounter-26.toml
+++ b/data/parties/euskal-encounter/euskal-encounter-26.toml
@@ -1,0 +1,15 @@
+slug = "euskal-encounter-26"
+title = "Euskal Encounter 26"
+series_slug = "euskal-encounter"
+organizer_entity = "Euskaltel Konekta"
+start_on = 2018-07-26
+end_on = 2018-07-29
+seats = 5088
+
+[location]
+name = "Bilbao Exhibition Centre (BEC)"
+country_code = "es"
+city = "Barakaldo"
+
+[links.website]
+url = "https://ee26.euskalencounter.org/"

--- a/data/parties/euskal-encounter/euskal-encounter-27.toml
+++ b/data/parties/euskal-encounter/euskal-encounter-27.toml
@@ -1,0 +1,15 @@
+slug = "euskal-encounter-27"
+title = "Euskal Encounter 27"
+series_slug = "euskal-encounter"
+organizer_entity = ["Asociación Euskalamiga", "Fundación Euskaltel"]
+start_on = 2019-07-25
+end_on = 2019-07-28
+seats = 4960
+
+[location]
+name = "Bilbao Exhibition Centre (BEC)"
+country_code = "es"
+city = "Barakaldo"
+
+[links.website]
+url = "https://ee27.euskalencounter.org/"

--- a/data/parties/euskal-encounter/euskal-encounter-28.toml
+++ b/data/parties/euskal-encounter/euskal-encounter-28.toml
@@ -1,0 +1,10 @@
+slug = "euskal-encounter-28"
+title = "Euskal Encounter 28"
+series_slug = "euskal-encounter"
+organizer_entity = ["Asociación Euskalamiga", "Fundación Euskaltel"]
+start_on = 2020-07-24
+end_on = 2020-07-26
+online = true
+
+[links.website]
+url = "https://ee28.euskalencounter.org/"

--- a/data/parties/euskal-encounter/euskal-encounter-29.toml
+++ b/data/parties/euskal-encounter/euskal-encounter-29.toml
@@ -1,0 +1,15 @@
+slug = "euskal-encounter-29"
+title = "Euskal Encounter 29"
+series_slug = "euskal-encounter"
+organizer_entity = ["Asociación Euskalamiga", "Fundación Euskaltel"]
+start_on = 2021-07-22
+end_on = 2021-07-25
+seats = 540
+
+[location]
+name = "Bilbao Exhibition Centre (BEC)"
+country_code = "es"
+city = "Barakaldo"
+
+[links.website]
+url = "https://ee29.euskalencounter.org/"

--- a/data/parties/euskal-encounter/euskal-encounter-30.toml
+++ b/data/parties/euskal-encounter/euskal-encounter-30.toml
@@ -1,0 +1,15 @@
+slug = "euskal-encounter-30"
+title = "Euskal Encounter 30"
+series_slug = "euskal-encounter"
+organizer_entity = ["Asociación Euskalamiga", "Fundación Euskaltel"]
+start_on = 2022-07-22
+end_on = 2022-07-25
+seats = 2976
+
+[location]
+name = "Bilbao Exhibition Centre (BEC)"
+country_code = "es"
+city = "Barakaldo"
+
+[links.website]
+url = "https://ee30.euskalencounter.org/"

--- a/data/parties/euskal-encounter/euskal-encounter-31.toml
+++ b/data/parties/euskal-encounter/euskal-encounter-31.toml
@@ -1,0 +1,15 @@
+slug = "euskal-encounter-31"
+title = "Euskal Encounter 31"
+series_slug = "euskal-encounter"
+organizer_entity = ["Asociación Euskalamiga", "Fundación Euskaltel"]
+start_on = 2023-07-22
+end_on = 2023-07-25
+seats = 3584
+
+[location]
+name = "Bilbao Exhibition Centre (BEC)"
+country_code = "es"
+city = "Barakaldo"
+
+[links.website]
+url = "https://ee31.euskalencounter.org/"

--- a/data/parties/euskal-encounter/euskal-encounter-32.toml
+++ b/data/parties/euskal-encounter/euskal-encounter-32.toml
@@ -1,0 +1,15 @@
+slug = "euskal-encounter-32"
+title = "Euskal Encounter 32"
+series_slug = "euskal-encounter"
+organizer_entity = ["Asociación Euskalamiga", "Fundación Euskaltel"]
+start_on = 2024-07-25
+end_on = 2024-07-28
+seats = 3904
+
+[location]
+name = "Bilbao Exhibition Centre (BEC)"
+country_code = "es"
+city = "Barakaldo"
+
+[links.website]
+url = "https://ee32.euskalencounter.org/"

--- a/data/parties/euskal-encounter/euskal-encounter-33.toml
+++ b/data/parties/euskal-encounter/euskal-encounter-33.toml
@@ -1,0 +1,15 @@
+slug = "euskal-encounter-33"
+title = "Euskal Encounter 33"
+series_slug = "euskal-encounter"
+organizer_entity = "Asociación Amigos de la Informática EUSKALAMIGA"
+start_on = 2025-07-24
+end_on = 2025-07-27
+seats = 4096
+
+[location]
+name = "Bilbao Exhibition Centre (BEC)"
+country_code = "es"
+city = "Barakaldo"
+
+[links.website]
+url = "https://ee33.euskalencounter.org/"

--- a/data/series/euskal-encounter.toml
+++ b/data/series/euskal-encounter.toml
@@ -1,0 +1,7 @@
+slug = "euskal-encounter"
+title = "Euskal Encounter"
+alternative_titles = ["Euskal Party", "Euskal Amiga Party"]
+country_codes = ["es"]
+
+[links.website]
+url = "https://www.euskalencounter.org/"


### PR DESCRIPTION
Hello, just want to contribute the data for the 'Euskal Encounter' party series (https://euskalencounter.org).

Some notes about the data:

Euskal Encounter has changed names slightly over the years, being known as 'Euskal Amiga Party' initially, then renamed to 'Euskal Party', and finally renamed to  the current 'Euskal Encounter' name.

All data has been collected from two main sources:
- Spanish wikipedia entry for the event series: https://es.wikipedia.org/wiki/Euskal_Encounter
- Previous editions section on the official event website: https://ee33.euskalencounter.org/en/32th-edition-2024.html

Thanks!